### PR TITLE
#23/애플 로그인

### DIFF
--- a/Jip-coon/Projects/App/Jip-coon.entitlements
+++ b/Jip-coon/Projects/App/Jip-coon.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Jip-coon/Projects/App/Project.swift
+++ b/Jip-coon/Projects/App/Project.swift
@@ -33,6 +33,7 @@ let project = Project(
             ),
             sources: ["Sources/**"],
             resources: ["Resources/**"],
+            entitlements: "Jip-coon.entitlements",
             dependencies: [
                 .project(target: "Feature", path: .relativeToRoot("Projects/Feature")),
                 .external(name: "FirebaseCore")

--- a/Jip-coon/Projects/Feature/Scenes/LoginScene/View/LoginViewController.swift
+++ b/Jip-coon/Projects/Feature/Scenes/LoginScene/View/LoginViewController.swift
@@ -179,6 +179,13 @@ public class LoginViewController: UIViewController {
                 self?.updateLoadingState(isLoading)
             }
             .store(in: &cancellables)
+        
+        appleLoginViewModel.loginSuccess
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.navigateToMainScreen()
+            }
+            .store(in: &cancellables)
     }
     
     private func navigateToMainScreen() {

--- a/Jip-coon/Projects/Feature/Scenes/LoginScene/View/LoginViewController.swift
+++ b/Jip-coon/Projects/Feature/Scenes/LoginScene/View/LoginViewController.swift
@@ -14,6 +14,7 @@ public class LoginViewController: UIViewController {
     private var savedContentOffset: CGPoint?
     private let loginView = LoginView()
     private let viewModel = LoginViewModel()
+    private let appleLoginViewModel = AppleLoginViewModel()
     private var cancellables = Set<AnyCancellable>()
     
     override public func loadView() {
@@ -84,6 +85,7 @@ public class LoginViewController: UIViewController {
     
     @objc private func appleLoginTapped() {
         print("apple login button tapped")
+        appleLoginViewModel.startSignInWithAppleFlow()
     }
     // MARK: - Keyboard
     

--- a/Jip-coon/Projects/Feature/Scenes/LoginScene/ViewModel/AppleLoginViewModel.swift
+++ b/Jip-coon/Projects/Feature/Scenes/LoginScene/ViewModel/AppleLoginViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import AuthenticationServices
+import Combine
 import CryptoKit
 import Foundation
 import FirebaseAuth
@@ -13,6 +14,7 @@ import FirebaseAuth
 final class AppleLoginViewModel: NSObject {
     // Unhashed nonce.
     fileprivate var currentNonce: String?
+    public let loginSuccess = PassthroughSubject<Void, Never>()
     
     @available(iOS 13, *)
     func startSignInWithAppleFlow() {
@@ -93,6 +95,7 @@ extension AppleLoginViewModel: ASAuthorizationControllerDelegate {
                     return
                 }
                 // 로그인에 성공했을 시 실행할 메서드 추가
+                self.loginSuccess.send()
             }
         }
     }

--- a/Jip-coon/Projects/Feature/Scenes/LoginScene/ViewModel/AppleLoginViewModel.swift
+++ b/Jip-coon/Projects/Feature/Scenes/LoginScene/ViewModel/AppleLoginViewModel.swift
@@ -1,0 +1,117 @@
+//
+//  AppleLoginViewModel.swift
+//  Feature
+//
+//  Created by 예슬 on 8/29/25.
+//
+
+import AuthenticationServices
+import CryptoKit
+import Foundation
+import FirebaseAuth
+
+final class AppleLoginViewModel: NSObject {
+    // Unhashed nonce.
+    fileprivate var currentNonce: String?
+    
+    @available(iOS 13, *)
+    func startSignInWithAppleFlow() {
+        let nonce = randomNonceString()
+        currentNonce = nonce
+        let appleIDProvider = ASAuthorizationAppleIDProvider()  // Apple ID 제공자를 생성
+        let request = appleIDProvider.createRequest()   // 인증 요청을 생성
+        request.requestedScopes = [.fullName, .email]   // 사용자로부터 전체 이름과 이메일을 요청
+        request.nonce = sha256(nonce)
+        
+        // 인증 요청을 처리할 컨트롤러를 생성
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self // 이 뷰 모델을 인증 컨트롤러의 delegate로 설정
+        authorizationController.presentationContextProvider = self  // 이 뷰 모델을 인증 컨트롤러의 프레젠테이션 컨텍스트 제공자로 설정
+        authorizationController.performRequests()   // 인증 요청을 수행
+    }
+    
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        var randomBytes = [UInt8](repeating: 0, count: length)
+        let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+        if errorCode != errSecSuccess {
+            fatalError(
+                "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
+            )
+        }
+        
+        let charset: [Character] =
+        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        
+        let nonce = randomBytes.map { byte in
+            // Pick a random character from the set, wrapping around if needed.
+            charset[Int(byte) % charset.count]
+        }
+        
+        return String(nonce)
+    }
+    
+    @available(iOS 13, *)
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            String(format: "%02x", $0)
+        }.joined()
+        
+        return hashString
+    }
+}
+
+
+extension AppleLoginViewModel: ASAuthorizationControllerDelegate {
+    // 로그인 성공
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            guard let nonce = currentNonce else {
+                fatalError("Invalid state: A login callback was received, but no login request was sent.")
+            }
+            guard let appleIDToken = appleIDCredential.identityToken else {
+                print("Unable to fetch identity token")
+                return
+            }
+            guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+                print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
+                return
+            }
+            // Initialize a Firebase credential, including the user's full name.
+            let credential = OAuthProvider.appleCredential(withIDToken: idTokenString,
+                                                           rawNonce: nonce,
+                                                           fullName: appleIDCredential.fullName)
+            // Sign in with Firebase.
+            Auth.auth().signIn(with: credential) { (authResult, error) in
+                if (error != nil) {
+                    // Error. If error.code == .MissingOrInvalidNonce, make sure
+                    // you're sending the SHA256-hashed nonce as a hex string with
+                    // your request to Apple.
+                    print(error?.localizedDescription ?? "")
+                    return
+                }
+                // 로그인에 성공했을 시 실행할 메서드 추가
+            }
+        }
+    }
+    
+    // 로그인 실패
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: any Error) {
+        print("로그인 실패", error.localizedDescription)
+    }
+}
+
+extension AppleLoginViewModel: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        // 현재 애플리케이션에서 활성화된 첫 번째 윈도우
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap({ $0.windows })
+            .first(where: { $0.isKeyWindow }) else {
+            fatalError("No key window found")
+        }
+        return window
+    }
+}

--- a/Jip-coon/Projects/Jip-coon.entitlements
+++ b/Jip-coon/Projects/Jip-coon.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string></string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #23 

👷 **작업한 내용**
- 애플 로그인 기능

## 🚨 참고 사항
- 이제 로그인이 구현됐으니 Firebase store rule 을 인가된 허용자는 이용할 수 있도록 바꿔두면 좋을 것 같아요.
- 저는 이메일 가리기 기능으로 가입해봤는데 회원탈퇴가 아니다보니 로그아웃을 해도, 다시 로그인 하면서 이메일 보이게 설정은 안 되더라고요!
- 파이어베이스에서 제 아이디를 지우고도 시도해봤는데, 이미 가입한 걸로 애플쪽에서 처리되어서 그런지 제 프로필이 바로 나타났습니다
- 그래서 이메일 공유하면서 가입하는 기능은 테스트를 못했어요ㅜㅜ
- 스크린샷에서 애플 로그인 처음 눌렀을 때 화면이 넘어가지 않는 것은 기능 구현 전이라 그렇습니다! (지금은 잘 됨)

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|애플 로그인 첫 시도|![ScreenRecording_08-30-2025 02-23-23_1](https://github.com/user-attachments/assets/4e536bb4-3148-4810-b290-a73d738e1279)|
|로그아웃 후 재로그인|![ScreenRecording_08-30-2025 02-35-53_1](https://github.com/user-attachments/assets/724ab446-024c-476a-8d74-b788a1f5f8cf)|


## 📟 관련 이슈
- Resolved: #23 
