### PR TITLE
[Feat] #53 - MainViewModel에 데이터 캐싱 시스템 및 뷰 상태 관리 추가

### DIFF
--- a/Jip-coon/Projects/Feature/Scenes/MainScene/View/MainViewController.swift
+++ b/Jip-coon/Projects/Feature/Scenes/MainScene/View/MainViewController.swift
@@ -36,7 +36,7 @@ public class MainViewController: UIViewController {
 
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        viewModel.refreshData()
+        viewModel.viewDidAppear()
     }
 
     public override func viewDidLayoutSubviews() {
@@ -52,6 +52,11 @@ public class MainViewController: UIViewController {
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.setNavigationBarHidden(false, animated: false)
+    }
+
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        viewModel.viewDidDisappear()
     }
 
     private func setupUI() {
@@ -180,7 +185,10 @@ public class MainViewController: UIViewController {
 
     private func markQuestAsCompleted(_ quest: Quest) {
         showCompletionAlert(for: quest)
-        viewModel.refreshData()
+        // 퀘스트 완료 후 캐시 무효화하여 다음 뷰 로드 시 최신 데이터 반영
+        viewModel.invalidateCache()
+        // 필요한 경우에만 데이터 리프레시
+        viewModel.refreshDataIfNeeded()
     }
 
     private func showQuestDetails(_ quest: Quest) {


### PR DESCRIPTION
메인 화면 탭 전환 시 UI 리로드 제거 및 캐시 구현

## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #53 

👷 **작업한 내용**
- 메인 화면 탭 전환 시 불필요한 데이터 리로드를 방지하는 캐싱 시스템 구현
- 데이터 캐싱 및 초기 로딩 상태 관리 로직 추가
- viewDidAppear에서 조건부 데이터 리프레시 구현  
- 5분 캐시 만료 시간 설정으로 불필요한 네트워크 요청 감소
- 뷰 가시성 상태 추적으로 성능 최적화
- 퀘스트 완료 시 캐시 무효화 메커니즘 추가

## 🚨 참고 사항
- 탭 전환 시 느린 UI 응답 속도 이슈

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|메인화면 탭 전환|![Simulator Screen Recording - iPhone 16 Pro - 2025-12-30 at 13 46 48](https://github.com/user-attachments/assets/75c838b4-1f11-4b17-8551-9956358555ad)|

## 📟 관련 이슈
- Resolved: #53 
